### PR TITLE
Minimal effort to get this to build 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,14 @@
 source 'https://rubygems.org'
 
-gem 'rake'
+gem 'rake', "~> 13"
 gem 'mime-types'
 gem 'mongo'
 gem 'mongoid'
-gem 'unicorn'
+gem 'unicorn', '>= 6.1.0'
 gem 'rspec'
 gem 'pry'
 gem 'ruby-prof'
 gem 'ox'
+gem "webrick", "~> 1.8"
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     dav4rack (0.3.0)
-      nokogiri (>= 1.4.2)
+      nokogiri (~> 1.14)
       ox (>= 2.1.0)
       rack (>= 1.1.0)
       uuidtools (~> 2.1.1)
@@ -27,7 +27,6 @@ GEM
     kgio (2.11.4)
     method_source (0.8.2)
     mime-types (1.17.2)
-    mini_portile2 (2.6.1)
     minitest (5.14.4)
     mongo (2.15.0)
       bson (>= 4.8.2, < 5.0.0)
@@ -35,8 +34,7 @@ GEM
       activemodel (>= 5.1, < 6.2)
       mongo (>= 2.10.5, < 3.0.0)
       ruby2_keywords (~> 0.0.5)
-    nokogiri (1.12.3)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
     ox (2.14.5)
     pry (0.10.0)
@@ -45,8 +43,8 @@ GEM
       slop (~> 3.4)
     racc (1.5.2)
     rack (2.2.3)
-    raindrops (0.8.0)
-    rake (0.9.2.2)
+    raindrops (0.20.1)
+    rake (13.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -65,15 +63,15 @@ GEM
     slop (3.5.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    unicorn (4.2.0)
+    unicorn (6.1.0)
       kgio (~> 2.6)
-      rack
       raindrops (~> 0.7)
     uuidtools (2.1.5)
+    webrick (1.8.1)
     zeitwerk (2.4.2)
 
 PLATFORMS
-  ruby
+  arm64-darwin-22
 
 DEPENDENCIES
   dav4rack!
@@ -82,10 +80,11 @@ DEPENDENCIES
   mongoid
   ox
   pry
-  rake
+  rake (~> 13)
   rspec
   ruby-prof
-  unicorn
+  unicorn (>= 6.1.0)
+  webrick (~> 1.8)
 
 BUNDLED WITH
-   2.2.8
+   2.4.8

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
-require 'rake/testtask'
+require 'rake'
+require 'rspec/core/rake_task'
 
-Rake::TestTask.new do |t|
-  t.pattern = 'spec/*.rb'
-end
+RSpec::Core::RakeTask.new(:spec)
+
+task :default  => :spec

--- a/dav4rack.gemspec
+++ b/dav4rack.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.executables << 'dav4rack'
   s.extra_rdoc_files = ['README.rdoc']
-  s.add_dependency 'nokogiri', '>= 1.4.2'
+  s.add_dependency 'nokogiri', '~> 1.14'
   s.add_dependency 'uuidtools', '~> 2.1.1'
   s.add_dependency 'rack', '>= 1.1.0'
   s.add_dependency 'ox', '>= 2.1.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  mongodb:
+    image: mongo:6-jammy
+    ports:
+      - '27017:27017'
+    volumes:
+      - mongo_data:/data/db
+volumes:
+  mongo_data:

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -5,7 +5,7 @@ require 'dav4rack'
 require 'fileutils'
 require 'nokogiri'
 
-describe DAV4Rack::Handler do
+RSpec.describe DAV4Rack::Handler do
   DOC_ROOT = File.expand_path(File.dirname(__FILE__) + '/htdocs')
   METHODS = %w(GET PUT POST DELETE PROPFIND PROPPATCH MKCOL COPY MOVE OPTIONS HEAD LOCK UNLOCK)  
   

--- a/spec/mongo_spec.rb
+++ b/spec/mongo_spec.rb
@@ -12,7 +12,7 @@ require 'mongoid'
 
 Mongoid.load!(File.join(File.dirname(__FILE__), 'config', 'mongoid.yml'), :test)
 
-describe DAV4Rack::Handler do
+RSpec.describe DAV4Rack::Handler do
   METHODS = %w(GET PUT POST DELETE PROPFIND PROPPATCH MKCOL COPY MOVE OPTIONS HEAD LOCK UNLOCK)
 
   let(:database) { Mongoid.client(:default).database }

--- a/spec/perf_spec.rb
+++ b/spec/perf_spec.rb
@@ -5,7 +5,7 @@ require 'dav4rack'
 require 'fileutils'
 require 'nokogiri'
 
-describe DAV4Rack::Handler do
+RSpec.describe DAV4Rack::Handler do
   DOC_ROOT = File.expand_path(File.dirname(__FILE__) + '/htdocs')
   METHODS = %w(GET PUT POST DELETE PROPFIND PROPPATCH MKCOL COPY MOVE OPTIONS HEAD LOCK UNLOCK)
 
@@ -137,7 +137,7 @@ describe DAV4Rack::Handler do
       end
     end
 
-    b.real.to_i.should == 1
+    b.real.to_i.should <= 1
 
 
     multistatus_response('/D:href').first.text.strip.should =~ /http:\/\/localhost(:\d+)?\//

--- a/test/script.sh
+++ b/test/script.sh
@@ -1,7 +1,9 @@
 #!/bin/sh 
 
-# Run buitin spec tests
-bundle exec rake test
+# Run builtin spec tests
+docker compose up -d
+bundle exec rake
+docker compose down
 
 if [ $? -ne 0 ] ; then
   echo "*** Specs failed to properly complete"
@@ -23,16 +25,16 @@ sleep 3
 
 DAV_PID=$?
 
-if [ ! -f /tmp/litmus/litmus-0.13.tar.gz ]; then
-  mkdir -p /tmp/litmus
-  wget -O /tmp/litmus/litmus-0.13.tar.gz http://www.webdav.org/neon/litmus/litmus-0.13.tar.gz
-  cd /tmp/litmus
-  tar -xzf litmus-0.13.tar.gz
-  cd /tmp/litmus/litmus-0.13
+if [ ! -d /tmp/litmus/litmus-0.14 ]; then
+  mkdir /tmp/litmus
+  git clone --recurse-submodules https://github.com/notroj/litmus.git /tmp/litmus/litmus-0.14/
+  cd /tmp/litmus/litmus-0.14
+  git checkout tags/0.14
+  ./autogen.sh
   ./configure
 fi
 
-cd /tmp/litmus/litmus-0.13 
+cd /tmp/litmus/litmus-0.14
 make URL=http://localhost:3000/ check
 
 LITMUS=$?

--- a/test/setup_script.sh
+++ b/test/setup_script.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
+set -e
+
 rm -rf /tmp/litmus
 mkdir /tmp/litmus
-wget -O /tmp/litmus/litmus-0.13.tar.gz http://www.webdav.org/neon/litmus/litmus-0.13.tar.gz
-tar -C /tmp/litmus -xvzf /tmp/litmus/litmus-0.13.tar.gz
-cd /tmp/litmus/litmus-0.13
+git clone --recurse-submodules https://github.com/notroj/litmus.git /tmp/litmus/litmus-0.14/
+cd /tmp/litmus/litmus-0.14
+git checkout tags/0.14
+./autogen.sh
 ./configure


### PR DESCRIPTION
This doesn't build anymore due to issues of all kind. This MR is an effort to get it to build again on "modern" systems (e.g. my Macbook).

Minimal effort to get this to build. Things done:
- Add a docker-compose to run Mongoid
- Use [notroj/litmus.git](https://github.com/notroj/litmus) to get it to build again
- Make sure we can run specs again by bumping Rake, Unicorn and Nokogiri
- Fix the performance spec because my machine is too fast

To test:
1. Clone the repo
2. Run `bundle`
3. Run `./test/script.sh`
4. Verify all tests pass, the `perf_spec` might not, it's a funny tests that checks whether a performance benchmark is done within a second 😁 

There is one Litmus spec that fails:

```
 8. copy_shallow.......... 127.0.0.1 - - [12/Apr/2023:13:26:43 +0200] "MKCOL /litmus/ccsrc HTTP/1.1" 201 - 0.0006
127.0.0.1 - - [12/Apr/2023:13:26:43 +0200] "PUT /litmus/ccsrc/foo HTTP/1.1" 201 38 0.0007
127.0.0.1 - - [12/Apr/2023:13:26:43 +0200] "DELETE /litmus/ccdest HTTP/1.1" 404 - 0.0003
127.0.0.1 - - [12/Apr/2023:13:26:43 +0200] "COPY /litmus/ccsrc HTTP/1.1" 207 188 0.0008
127.0.0.1 - - [12/Apr/2023:13:26:43 +0200] "DELETE /litmus/ccsrc HTTP/1.1" 204 - 0.0005
127.0.0.1 - - [12/Apr/2023:13:26:43 +0200] "DELETE /litmus/ccdest/foo HTTP/1.1" 204 - 0.0004
 copy_shallow.......... FAIL (DELETE on `/litmus/ccdest/foo' should fail with 404: got 204)
 ```

Running the master branch on 0.13 (in a cursed Linux docker container), the spec passes:

```
 8. copy_shallow.......... 127.0.0.1 - - [12/Apr/2023:13:24:49 +0200] "MKCOL /litmus/ccsrc HTTP/1.1" 201 - 0.0003
127.0.0.1 - - [12/Apr/2023:13:24:49 +0200] "PUT /litmus/ccsrc/foo HTTP/1.1" 201 38 0.0004
127.0.0.1 - - [12/Apr/2023:13:24:49 +0200] "DELETE /litmus/ccdest HTTP/1.1" 404 - 0.0002
127.0.0.1 - - [12/Apr/2023:13:24:49 +0200] "COPY /litmus/ccsrc HTTP/1.1" 207 188 0.0005
127.0.0.1 - - [12/Apr/2023:13:24:49 +0200] "DELETE /litmus/ccsrc HTTP/1.1" 204 - 0.0002
127.0.0.1 - - [12/Apr/2023:13:24:49 +0200] "DELETE /litmus/foo HTTP/1.1" 404 - 0.0003
127.0.0.1 - - [12/Apr/2023:13:24:49 +0200] "DELETE /litmus/ccdest HTTP/1.1" 204 - 0.0003
 8. copy_shallow.......... pass
```

But there's a difference! The last `DELETE` action sent goes to `litmus/ccdest/foo` with Litmus 0.14 and to `litmus/ccdest` with Litmus 0.13. This is because of the following change: https://github.com/notroj/litmus/commit/6e2cd5ed698a812c419f5bcdbd22baf07b8c462e

When we "cherry-pick" that line into our cursed Linux docker container, rebuild Litmus, and run the spec on master on 0.13, we can see that the tests starts failing too:

```
 8. copy_shallow.......... 127.0.0.1 - - [12/Apr/2023:13:33:04 +0200] "MKCOL /litmus/ccsrc HTTP/1.1" 201 - 0.0002
127.0.0.1 - - [12/Apr/2023:13:33:04 +0200] "PUT /litmus/ccsrc/foo HTTP/1.1" 201 38 0.0004
127.0.0.1 - - [12/Apr/2023:13:33:04 +0200] "DELETE /litmus/ccdest HTTP/1.1" 404 - 0.0002
127.0.0.1 - - [12/Apr/2023:13:33:04 +0200] "COPY /litmus/ccsrc HTTP/1.1" 207 188 0.0005
127.0.0.1 - - [12/Apr/2023:13:33:04 +0200] "DELETE /litmus/ccsrc HTTP/1.1" 204 - 0.0003
127.0.0.1 - - [12/Apr/2023:13:33:04 +0200] "DELETE /litmus/ccdest/foo HTTP/1.1" 204 - 0.0002
 8. copy_shallow.......... FAIL (DELETE on `/litmus/ccdest/foo' should fail with 404: got 204)
```

So this is good news and bad news:
- Bad: dav4rack does not implement the Dav RFC completely
- Good: this branch is idempotent with master, meaning we don't have to fix this 😁 